### PR TITLE
Fixed failing tests

### DIFF
--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -32,7 +32,8 @@ migrate = Migrate(app, db)
 
 # Handle circular imports
 from .active_learning import train_and_predict  # noqa: E402
-from app.models import LabeledFile, Model, Prediction, ConfusionMatrix, Accuracy
+from app import routes, models  # noqa: E402, F401
+from app.models import LabeledFile, Model, Prediction, ConfusionMatrix, Accuracy # noqa: E402
 
 if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
     # The app is not in debug mode or we are in the reloaded process

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -33,7 +33,8 @@ migrate = Migrate(app, db)
 # Handle circular imports
 from .active_learning import train_and_predict  # noqa: E402
 from app import routes, models  # noqa: E402, F401
-from app.models import LabeledFile, Model, Prediction, ConfusionMatrix, Accuracy # noqa: E402
+from app.models import (LabeledFile, Model,  # noqa: E402
+                        Prediction, ConfusionMatrix, Accuracy)
 
 if not app.debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
     # The app is not in debug mode or we are in the reloaded process

--- a/api/app/routes.py
+++ b/api/app/routes.py
@@ -115,7 +115,7 @@ def get_statistics():
             'progress': session['cur_labels'],
             'goal': session['goal']
         },
-        'confusionMatrix': confusion_matrix,
+        'confusionMatrix': list(confusion_matrix),
         'accuracy': {
             'train': train,
             'validation': validation

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,8 +1,12 @@
 import pytest
-from app import app, db
+import sys
 import os
-
+from dotenv import load_dotenv
+load_dotenv()
 basedir = os.path.abspath(os.path.dirname(__file__))
+rootdir = os.path.dirname(basedir)
+sys.path.append(rootdir)
+from app import app, db  # noqa: E402
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Resolves #18. While implementing the GH Action workflows and performing linting, I made changes that caused the API endpoint service to fail. The changes made are as follows:
- Reinstating `from app import routes, models`, without which flask will not be able to locate the routes and start up the server properly on initialization. 

Following changes were also made to pass the failing tests: 
- Converting confusion matrix from a list containing a tuple to just a list, so for e.g. `[(1, 2, 3, 4)]` --> `[1, 2, 3, 4]`. Fixes error that a tuple cannot be sent in a JSON response message, but a list can. Not sure if this might be an issue due to recent dependency updates. 
- Appending directory path of the API endpoint to `sys.path` and using `dotenv` library, so that pytest can locate and load the necessary environment variables in the .env file. 