### PR TITLE
Improve health check hotfix

### DIFF
--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -1,6 +1,9 @@
 name: Scheduled Check
 
 on:
+  push:
+    branches:
+      - improve-healthcheck
   schedule:
     - cron:  '30 17 * * 3,6'
 
@@ -8,7 +11,7 @@ jobs:
   scheduled_check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check the deployed service URL
+      - name: Check the github actions 
         uses: jtalk/url-health-check-action@v2
         with:
           url: https://orcasound.github.io/orcaal/
@@ -16,3 +19,9 @@ jobs:
           max-attempts: 3
           retry-delay: 5s
           retry-all: false
+      - name: Check lightsail instance
+        run: curl {{ secrets.LIGHTSAIL_IP }}
+      - name: Check postgres database
+        run: |
+          sudo apt-get install -y nmap
+          nmap -p {{ secrets.POSTGRES_PORT }} {{ secrets.LIGHTSAIL_IP }}

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -8,7 +8,7 @@ jobs:
   scheduled_check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check the github actions 
+      - name: Check the github pages site
         uses: jtalk/url-health-check-action@v2
         with:
           url: https://orcasound.github.io/orcaal/

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -20,8 +20,8 @@ jobs:
           retry-delay: 5s
           retry-all: false
       - name: Check lightsail instance
-        run: curl {{ secrets.LIGHTSAIL_IP }}
+        run: curl ${{ secrets.LIGHTSAIL_IP }}
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          nmap -p {{ secrets.POSTGRES_PORT }} {{ secrets.LIGHTSAIL_IP }}
+          nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }}

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -19,14 +19,10 @@ jobs:
           max-attempts: 3
           retry-delay: 5s
           retry-all: false
-      - name: "grep matching pattern"
-        run: |
-         # Everything works fine
-          echo "foo" | grep "foo"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          echo $(nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }}) | grep postgresql
+          echo $(nmap -p 777 ${{ secrets.LIGHTSAIL_IP }}) | grep postgresql
       - name: Check lightsail instance
         run: |
           echo $(curl ${{ secrets.LIGHTSAIL_IP }}) | grep "Active Learning API is running!"

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -1,9 +1,6 @@
 name: Scheduled Check
 
 on:
-  push:
-    branches:
-      - improve-healthcheck
   schedule:
     - cron:  '30 17 * * 3,6'
 
@@ -19,10 +16,10 @@ jobs:
           max-attempts: 3
           retry-delay: 5s
           retry-all: false
+      - name: Check lightsail instance
+        run: |
+          echo $(curl ${{ secrets.LIGHTSAIL_IP }}) | grep "Active Learning API is running!"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
           echo $(nmap -p 777 ${{ secrets.LIGHTSAIL_IP }}) | grep postgresql
-      - name: Check lightsail instance
-        run: |
-          echo $(curl ${{ secrets.LIGHTSAIL_IP }}) | grep "Active Learning API is running!"

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }} | grep postgresql
+          echo $(nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }}) | grep postgresql
       - name: Check lightsail instance
         run: |
-          curl ${{ secrets.LIGHTSAIL_IP }} | grep "Active Learning API is running!"
+          echo $(curl ${{ secrets.LIGHTSAIL_IP }}) | grep "Active Learning API is running!"

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -19,6 +19,10 @@ jobs:
           max-attempts: 3
           retry-delay: 5s
           retry-all: false
+      - name: "grep matching pattern"
+        run: |
+         # Everything works fine
+          echo "foo" | grep "foo"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -20,7 +20,8 @@ jobs:
           retry-delay: 5s
           retry-all: false
       - name: Check lightsail instance
-        run: curl ${{ secrets.LIGHTSAIL_IP }} | grep "Active Learning API is running!"
+        run: |
+          curl ${{ secrets.LIGHTSAIL_IP }} | grep "Active Learning API is running!"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -20,8 +20,8 @@ jobs:
           retry-delay: 5s
           retry-all: false
       - name: Check lightsail instance
-        run: curl ${{ secrets.LIGHTSAIL_IP }}
+        run: curl ${{ secrets.LIGHTSAIL_IP }} | grep "Active Learning API is running!"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }}
+          nmap -p 777 ${{ secrets.LIGHTSAIL_IP }} | grep postgresql

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -21,8 +21,8 @@ jobs:
           retry-all: false
       - name: Check lightsail instance
         run: |
-          curl ${{ secrets.LIGHTSAIL_IP }} | grep "Active Learning API is running!"
+          curl "${{ secrets.LIGHTSAIL_IP }}" | grep "Active Learning API is running!"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          nmap -p 777 ${{ secrets.LIGHTSAIL_IP }} | grep postgresql
+          nmap -p 777 "${{ secrets.LIGHTSAIL_IP }}" | grep postgresql

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          echo $(nmap -p 777 ${{ secrets.LIGHTSAIL_IP }}) | grep postgresql
+          echo $(nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }}) | grep postgresql

--- a/.github/workflows/scheduled_check.yml
+++ b/.github/workflows/scheduled_check.yml
@@ -19,10 +19,10 @@ jobs:
           max-attempts: 3
           retry-delay: 5s
           retry-all: false
-      - name: Check lightsail instance
-        run: |
-          curl "${{ secrets.LIGHTSAIL_IP }}" | grep "Active Learning API is running!"
       - name: Check postgres database
         run: |
           sudo apt-get install -y nmap
-          nmap -p 777 "${{ secrets.LIGHTSAIL_IP }}" | grep postgresql
+          nmap -p ${{ secrets.POSTGRES_PORT }} ${{ secrets.LIGHTSAIL_IP }} | grep postgresql
+      - name: Check lightsail instance
+        run: |
+          curl ${{ secrets.LIGHTSAIL_IP }} | grep "Active Learning API is running!"


### PR DESCRIPTION
# Reason for hotfix:
Realized that I was using a random port number previously to check if the health check will fail, but forgot to revert it back to the correct port number of the postgres database. 

# Changes made:
Reverting to the correct port number of the postgres database

# Actions required:
- Add secret `POSTGRES_PORT` with value `5432` to OrcaAL repository secrets
- Add secret `LIGHTSAIL_IP` with value `35.80.163.168` to OrcaAL repository secrets (if not already done so)